### PR TITLE
Hide the scrollbar when the info-card is animating

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
 <script src="bower_components/webcomponentsjs/webcomponents-lite.min.js" async></script>
 <link rel="import" href="elements.build.html" async>
 <style is="custom-style">
+  body {
+    overflow:hidden;  
+  }
+  
   body.loaded #loading {
     opacity: 0;
   }


### PR DESCRIPTION
This is an easy fix of not showing the scrollbar when the `info-dialog` is animating (hiding or showing). 
Alternatively, if the main content area should be scrollable, one could probably use `position: static` instead of `absolute` for the dialog.
